### PR TITLE
Serve media publicly and add customizable UI features

### DIFF
--- a/backend/src/entities/site.entity.ts
+++ b/backend/src/entities/site.entity.ts
@@ -25,6 +25,9 @@ export class Site {
   faviconUrl: string;
 
   @Column({ nullable: true })
+  backgroundImageUrl: string;
+
+  @Column({ nullable: true })
   domain: string;
 
   @Column({ type: 'text', nullable: true })

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,11 +1,18 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AuthService } from './modules/auth/auth.service';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  // Serve uploaded files
+  app.useStaticAssets(join(process.cwd(), 'uploads'), {
+    prefix: '/uploads/',
+  });
   
   // Enable CORS
   app.enableCors({

--- a/backend/src/modules/media/media.controller.ts
+++ b/backend/src/modules/media/media.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Get, Delete, Param, UseGuards, UseInterceptors, UploadedFile } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { MediaService } from './media.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiConsumes, ApiBody, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('Media')
@@ -32,11 +32,9 @@ export class MediaController {
     return this.mediaService.uploadFile(file);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Get()
   @ApiOperation({ summary: 'Get all uploaded files' })
   @ApiResponse({ status: 200, description: 'List of all uploaded files' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAllFiles() {
     return this.mediaService.getAllFiles();
   }

--- a/backend/src/modules/sites/dto/create-site.dto.ts
+++ b/backend/src/modules/sites/dto/create-site.dto.ts
@@ -25,6 +25,11 @@ export class CreateSiteDto {
   @IsString()
   faviconUrl?: string;
 
+  @ApiProperty({ description: 'Background image URL', required: false })
+  @IsOptional()
+  @IsString()
+  backgroundImageUrl?: string;
+
   @ApiProperty({ description: 'Domain', required: false })
   @IsOptional()
   @IsString()

--- a/frontend/src/app/components/header/header.component.ts
+++ b/frontend/src/app/components/header/header.component.ts
@@ -8,6 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSelectModule } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 import { LanguageService } from '../../services/language.service';
 import { SiteService } from '../../services/site.service';
@@ -24,7 +25,8 @@ import { SiteService } from '../../services/site.service';
     MatIconModule,
     MatMenuModule,
     MatSelectModule,
-    FormsModule
+    FormsModule,
+    MatFormFieldModule
   ],
   template: `
     <mat-toolbar color="primary" class="header-toolbar">
@@ -73,13 +75,15 @@ import { SiteService } from '../../services/site.service';
 
         <!-- Language Switcher -->
         <div class="language-switcher">
-          <mat-select 
-            [value]="currentLanguage" 
-            (selectionChange)="onLanguageChange($event.value)"
-            class="language-select">
-            <mat-option value="sk">{{ 'COMMON.SLOVAK' | translate }}</mat-option>
-            <mat-option value="en">{{ 'COMMON.ENGLISH' | translate }}</mat-option>
-          </mat-select>
+          <mat-form-field appearance="outline" class="language-select">
+            <mat-label>{{ 'COMMON.LANGUAGE' | translate }}</mat-label>
+            <mat-select
+              [value]="currentLanguage"
+              (selectionChange)="onLanguageChange($event.value)">
+              <mat-option value="sk">{{ 'COMMON.SLOVAK' | translate }}</mat-option>
+              <mat-option value="en">{{ 'COMMON.ENGLISH' | translate }}</mat-option>
+            </mat-select>
+          </mat-form-field>
         </div>
 
         <!-- Mobile Menu Button -->
@@ -200,6 +204,10 @@ import { SiteService } from '../../services/site.service';
     }
 
     .language-select ::ng-deep .mat-mdc-select-arrow {
+      color: white;
+    }
+
+    .language-select ::ng-deep .mat-mdc-form-field-label {
       color: white;
     }
 

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -2,37 +2,86 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { AuthService } from '../../services/auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, TranslateModule, MatCardModule],
+  imports: [
+    CommonModule,
+    TranslateModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    ReactiveFormsModule
+  ],
   template: `
     <div class="login-container">
-      <div class="container">
-        <h1>Login</h1>
-        <p>Login page coming soon...</p>
-      </div>
+      <mat-card class="login-card">
+        <h1>{{ 'LOGIN.TITLE' | translate }}</h1>
+        <form [formGroup]="form" (ngSubmit)="onSubmit()">
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>{{ 'LOGIN.EMAIL' | translate }}</mat-label>
+            <input matInput formControlName="email" type="email" required />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>{{ 'LOGIN.PASSWORD' | translate }}</mat-label>
+            <input matInput formControlName="password" type="password" required />
+          </mat-form-field>
+
+          <button mat-raised-button color="primary" class="full-width" type="submit" [disabled]="form.invalid">
+            {{ 'LOGIN.SUBMIT' | translate }}
+          </button>
+        </form>
+      </mat-card>
     </div>
   `,
   styles: [`
     .login-container {
       padding: 80px 0;
       min-height: calc(100vh - 64px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
-    .container {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 0 20px;
+    .login-card {
+      width: 100%;
+      max-width: 400px;
+      padding: 20px;
+    }
+
+    .full-width {
+      width: 100%;
     }
 
     h1 {
-      font-size: 2.5rem;
-      color: #333;
-      margin-bottom: 1rem;
       text-align: center;
+      margin-bottom: 1rem;
     }
   `]
 })
-export class LoginComponent {}
+export class LoginComponent {
+  form = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', Validators.required]
+  });
+
+  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router) {}
+
+  onSubmit() {
+    if (this.form.valid) {
+      const { email, password } = this.form.value;
+      this.auth.login(email!, password!).subscribe(() => {
+        this.router.navigate(['/admin']);
+      });
+    }
+  }
+}

--- a/frontend/src/app/services/site.service.ts
+++ b/frontend/src/app/services/site.service.ts
@@ -16,6 +16,11 @@ export class SiteService {
       if (site?.theme) {
         this.applyTheme(site.theme);
       }
+      if (site?.backgroundImageUrl) {
+        this.applyBackground(site.backgroundImageUrl);
+      } else {
+        this.clearBackground();
+      }
     });
   }
 
@@ -37,5 +42,20 @@ export class SiteService {
     if (!path) return '';
     const base = environment.apiUrl.replace(/\/api$/, '');
     return path.startsWith('http') ? path : `${base}${path}`;
+  }
+
+  private applyBackground(imagePath: string) {
+    const url = this.resolveMediaUrl(imagePath);
+    document.body.style.backgroundImage = `url('${url}')`;
+    document.body.style.backgroundSize = 'cover';
+    document.body.style.backgroundRepeat = 'no-repeat';
+    document.body.style.backgroundAttachment = 'fixed';
+  }
+
+  private clearBackground() {
+    document.body.style.backgroundImage = '';
+    document.body.style.backgroundSize = '';
+    document.body.style.backgroundRepeat = '';
+    document.body.style.backgroundAttachment = '';
   }
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -125,5 +125,11 @@
     "ALL_RIGHTS_RESERVED": "All rights reserved",
     "PRIVACY_POLICY": "Privacy Policy",
     "TERMS_OF_SERVICE": "Terms of Service"
+  },
+  "LOGIN": {
+    "TITLE": "Admin Login",
+    "EMAIL": "Email",
+    "PASSWORD": "Password",
+    "SUBMIT": "Login"
   }
 }

--- a/frontend/src/assets/i18n/sk.json
+++ b/frontend/src/assets/i18n/sk.json
@@ -125,5 +125,11 @@
     "ALL_RIGHTS_RESERVED": "Všetky práva vyhradené",
     "PRIVACY_POLICY": "Ochrana súkromia",
     "TERMS_OF_SERVICE": "Podmienky používania"
+  },
+  "LOGIN": {
+    "TITLE": "Prihlásenie administrátora",
+    "EMAIL": "Email",
+    "PASSWORD": "Heslo",
+    "SUBMIT": "Prihlásiť sa"
   }
 }


### PR DESCRIPTION
## Summary
- Serve uploaded media files publicly and allow unauthenticated listing
- Support site-wide background images and keep themes selectable from database
- Add admin login page and improve language selector with label and Slovak default

## Testing
- `cd backend && npm test` *(fails: No tests found)*
- `cd ../frontend && npm test` *(fails: No Chrome browser available)*

------
https://chatgpt.com/codex/tasks/task_e_6895c51df1508324b3924efdc067d434