### PR TITLE
Add SQLite data source and connection test

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+database/*
+!database/.gitkeep

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,24 +14,12 @@ import { OrdersModule } from './modules/orders/orders.module';
 import { MediaModule } from './modules/media/media.module';
 import { SeederModule } from './modules/seeder/seeder.module';
 
-import { User } from './entities/user.entity';
-import { Site } from './entities/site.entity';
-import { Category } from './entities/category.entity';
-import { Product } from './entities/product.entity';
-import { ProductImage } from './entities/product-image.entity';
-import { Page } from './entities/page.entity';
-import { Order } from './entities/order.entity';
-import { SiteImage } from './entities/site-image.entity';
+import { AppDataSource } from './data-source';
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
-    TypeOrmModule.forRoot({
-      type: 'sqlite',
-      database: 'database/cms.db',
-      entities: [User, Site, Category, Product, ProductImage, Page, Order, SiteImage],
-      synchronize: true,
-    }),
+    TypeOrmModule.forRoot(AppDataSource.options),
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'uploads'),
       serveRoot: '/uploads',

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,0 +1,25 @@
+import { DataSource } from 'typeorm';
+import { User } from './entities/user.entity';
+import { Site } from './entities/site.entity';
+import { Category } from './entities/category.entity';
+import { Product } from './entities/product.entity';
+import { ProductImage } from './entities/product-image.entity';
+import { Page } from './entities/page.entity';
+import { Order } from './entities/order.entity';
+import { SiteImage } from './entities/site-image.entity';
+
+export const AppDataSource = new DataSource({
+  type: 'sqlite',
+  database: 'database/cms.db',
+  entities: [
+    User,
+    Site,
+    Category,
+    Product,
+    ProductImage,
+    Page,
+    Order,
+    SiteImage,
+  ],
+  synchronize: true,
+});

--- a/backend/src/sqlite-connection.spec.ts
+++ b/backend/src/sqlite-connection.spec.ts
@@ -1,0 +1,47 @@
+import { DataSource } from 'typeorm';
+import { User } from './entities/user.entity';
+import { Site } from './entities/site.entity';
+import { Category } from './entities/category.entity';
+import { Product } from './entities/product.entity';
+import { ProductImage } from './entities/product-image.entity';
+import { Page } from './entities/page.entity';
+import { Order } from './entities/order.entity';
+import { SiteImage } from './entities/site-image.entity';
+
+describe('SQLite connection', () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      entities: [
+        User,
+        Site,
+        Category,
+        Product,
+        ProductImage,
+        Page,
+        Order,
+        SiteImage,
+      ],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    if (dataSource && dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it('should initialize connection', () => {
+    expect(dataSource.isInitialized).toBe(true);
+  });
+
+  it('should run a simple query', async () => {
+    const result = await dataSource.query('SELECT 1 as result');
+    expect(result[0].result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- expose central SQLite `AppDataSource`
- wire NestJS `AppModule` to the shared data source
- add Jest test verifying SQLite connectivity

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6895da2c7b348324b5694e1b5e960e11